### PR TITLE
remove ability for Feral Ratlantean bosses to spawn in the overworld

### DIFF
--- a/data/apotheotic_additions/bosses/rats/feral_ratlantean.json
+++ b/data/apotheotic_additions/bosses/rats/feral_ratlantean.json
@@ -14,7 +14,7 @@
 		"#rats"
 	],
 	"dimensions": [
-		"minecraft:overworld", "rats:ratlantis"
+		"rats:ratlantis"
 	],
 	"min_rarity": "uncommon",
 	"max_rarity": "rare",


### PR DESCRIPTION
As described in #41, the Feral Ratlantean can spawn in the overworld as an invading boss and drop post-netherite gear in early game (as well as being easily cheeseable). This PR modifies the data so that they can't spawn in the overworld (as they can only spawn in Ratlantis in the actual mod).